### PR TITLE
feat: 서비스 기본 도메인 설계

### DIFF
--- a/src/main/java/com/nexters/jjanji/challenge/domain/Challenge.java
+++ b/src/main/java/com/nexters/jjanji/challenge/domain/Challenge.java
@@ -20,7 +20,8 @@ public class Challenge {
     @Column(name = "challenge_id")
     private Long id;
 
-    private LocalDateTime startDate;
+    @Column(nullable = false)
+    private LocalDateTime startAt;
 
-    private LocalDateTime endDate;
+    private LocalDateTime endAt;
 }

--- a/src/main/java/com/nexters/jjanji/challenge/domain/Challenge.java
+++ b/src/main/java/com/nexters/jjanji/challenge/domain/Challenge.java
@@ -1,0 +1,26 @@
+package com.nexters.jjanji.challenge.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@Entity
+public class Challenge {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "challenge_id")
+    private Long id;
+
+    private LocalDateTime startDate;
+
+    private LocalDateTime endDate;
+}

--- a/src/main/java/com/nexters/jjanji/challenge/domain/Challenge.java
+++ b/src/main/java/com/nexters/jjanji/challenge/domain/Challenge.java
@@ -23,5 +23,6 @@ public class Challenge {
     @Column(nullable = false)
     private LocalDateTime startAt;
 
+    @Column(nullable = false)
     private LocalDateTime endAt;
 }

--- a/src/main/java/com/nexters/jjanji/challenge/domain/Participation.java
+++ b/src/main/java/com/nexters/jjanji/challenge/domain/Participation.java
@@ -1,0 +1,43 @@
+package com.nexters.jjanji.challenge.domain;
+
+import com.nexters.jjanji.member.domain.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.ConstraintMode;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@Entity
+public class Participation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "plan_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "challenge_id", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private Challenge challenge;
+
+    @OneToMany(mappedBy = "participation")
+    private List<Plan> plan;
+
+}

--- a/src/main/java/com/nexters/jjanji/challenge/domain/Participation.java
+++ b/src/main/java/com/nexters/jjanji/challenge/domain/Participation.java
@@ -3,7 +3,6 @@ package com.nexters.jjanji.challenge.domain;
 import com.nexters.jjanji.member.domain.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.ConstraintMode;
-import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.ForeignKey;
@@ -12,12 +11,8 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.io.Serializable;
-import java.util.List;
 
 @Getter
 @NoArgsConstructor
@@ -26,7 +21,7 @@ public class Participation {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "plan_id")
+    @Column(name = "participation_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -36,8 +31,5 @@ public class Participation {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "challenge_id", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private Challenge challenge;
-
-    @OneToMany(mappedBy = "participation")
-    private List<Plan> plan;
 
 }

--- a/src/main/java/com/nexters/jjanji/challenge/domain/Plan.java
+++ b/src/main/java/com/nexters/jjanji/challenge/domain/Plan.java
@@ -31,4 +31,10 @@ public class Plan {
     @Column(nullable = false)
     private PlanCategory category;
 
+    @Column(nullable = false)
+    private Long goalAmount;
+
+    @Column(nullable = false, columnDefinition = "bigint default 0")
+    private Long currentAmount;
+
 }

--- a/src/main/java/com/nexters/jjanji/challenge/domain/Plan.java
+++ b/src/main/java/com/nexters/jjanji/challenge/domain/Plan.java
@@ -1,0 +1,34 @@
+package com.nexters.jjanji.challenge.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinColumns;
+import jakarta.persistence.ManyToOne;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Entity
+public class Plan {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "plan_id")
+    private Long id;
+
+    @ManyToOne
+    private Participation participation;
+
+    private String title;
+
+    private PlanCategory category;
+
+    public void setParticipation(Participation participation) {
+        this.participation = participation;
+    }
+}

--- a/src/main/java/com/nexters/jjanji/challenge/domain/Plan.java
+++ b/src/main/java/com/nexters/jjanji/challenge/domain/Plan.java
@@ -1,12 +1,14 @@
 package com.nexters.jjanji.challenge.domain;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.ConstraintMode;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.JoinColumns;
 import jakarta.persistence.ManyToOne;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -21,14 +23,10 @@ public class Plan {
     @Column(name = "plan_id")
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "participation_id", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private Participation participation;
-
-    private String title;
 
     private PlanCategory category;
 
-    public void setParticipation(Participation participation) {
-        this.participation = participation;
-    }
 }

--- a/src/main/java/com/nexters/jjanji/challenge/domain/Plan.java
+++ b/src/main/java/com/nexters/jjanji/challenge/domain/Plan.java
@@ -1,5 +1,6 @@
 package com.nexters.jjanji.challenge.domain;
 
+import com.nexters.jjanji.challenge.specification.PlanCategory;
 import jakarta.persistence.Column;
 import jakarta.persistence.ConstraintMode;
 import jakarta.persistence.Entity;
@@ -27,6 +28,7 @@ public class Plan {
     @JoinColumn(name = "participation_id", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private Participation participation;
 
+    @Column(nullable = false)
     private PlanCategory category;
 
 }

--- a/src/main/java/com/nexters/jjanji/challenge/domain/PlanCategory.java
+++ b/src/main/java/com/nexters/jjanji/challenge/domain/PlanCategory.java
@@ -1,4 +1,0 @@
-package com.nexters.jjanji.challenge.domain;
-
-public enum PlanCategory {
-}

--- a/src/main/java/com/nexters/jjanji/challenge/domain/PlanCategory.java
+++ b/src/main/java/com/nexters/jjanji/challenge/domain/PlanCategory.java
@@ -1,0 +1,4 @@
+package com.nexters.jjanji.challenge.domain;
+
+public enum PlanCategory {
+}

--- a/src/main/java/com/nexters/jjanji/challenge/specification/PlanCategory.java
+++ b/src/main/java/com/nexters/jjanji/challenge/specification/PlanCategory.java
@@ -1,0 +1,4 @@
+package com.nexters.jjanji.challenge.specification;
+
+public enum PlanCategory {
+}

--- a/src/main/java/com/nexters/jjanji/common/domain/BaseTime.java
+++ b/src/main/java/com/nexters/jjanji/common/domain/BaseTime.java
@@ -1,0 +1,25 @@
+package com.nexters.jjanji.common.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseTime {
+
+    @JsonIgnore
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @JsonIgnore
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/nexters/jjanji/member/domain/Member.java
+++ b/src/main/java/com/nexters/jjanji/member/domain/Member.java
@@ -1,5 +1,6 @@
 package com.nexters.jjanji.member.domain;
 
+import com.nexters.jjanji.common.domain.BaseTime;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -17,7 +18,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "member", indexes = {
         @Index(name = "idx_member_device_id", columnList = "device_id", unique = true)
 })
-public class Member {
+public class Member extends BaseTime {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "member_id")


### PR DESCRIPTION
❗️ 이슈 번호
close #4 


📝 구현 내용
(가능한 한 자세히 작성해 주시면 감사하겠습니다!)
이후 작업 분리를 위해 미리 도메인만 빠르게 작성했습니다.

- JPA 양방향 연관관계는 필요한 경우에만 열기
- index 필요한 경우에만 그때그때 생성

### 각 도메인 설명
Challenge: 챌린지 정보
  - Participation: 참여에 대한 정보. 참여한 경우에만 생성.
    - Plan: 유저가 정의한 세부 계획

### 다이어그램
![스크린샷 2023-07-10 오전 7 27 37](https://github.com/Nexters/zzanji-server/assets/76773202/6fe00810-c695-4602-8d1c-97bc71c29446)

### 실제 생성
![스크린샷 2023-07-10 오전 7 24 20](https://github.com/Nexters/zzanji-server/assets/76773202/4d76c7b4-c889-41c7-a17e-9af1bcfbfe14)




🙇🏻‍♂️ 리뷰어에게 부탁합니다!

데이터 구조가 RDB에 적합한 구조가 아님을 느끼는군요 ㅋㅋ
Plan 때문에 차라리 NoSQL이 더 적합하긴 한 것 같습니다 ~~~

이것저것 적용해보니, 그나마 이게 나은 것 같습니다.


💡 참고 자료
(없다면 지워도 됩니다!)