### PR TITLE
docs: spring rest docs 문서화 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,8 @@ out/
 
 ### VS Code ###
 .vscode/
+
+# Generated files
+.idea/**/contentModel.xml
+**/resources/static/docs
+src/docs/asciidoc/rescode.adoc

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.1.1'
 	id 'io.spring.dependency-management' version '1.1.0'
+	id 'org.asciidoctor.jvm.convert' version '3.3.2'
 }
 
 group = 'com.nexters'
@@ -12,6 +13,7 @@ java {
 }
 
 configurations {
+	asciidoctorExtensions
 	compileOnly {
 		extendsFrom annotationProcessor
 	}
@@ -28,8 +30,54 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	asciidoctorExtensions 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 }
 
-tasks.named('test') {
+ext {
+	snippetsDir = file('build/generated-snippets')
+}
+
+test {
 	useJUnitPlatform()
+	outputs.dir snippetsDir
+}
+
+asciidoctor {
+	forkOptions {
+		jvmArgs('--add-opens', 'java.base/sun.nio.ch=ALL-UNNAMED')
+		jvmArgs('--add-opens', 'java.base/java.io=ALL-UNNAMED')
+	}
+	dependsOn test
+	configurations 'asciidoctorExtensions'
+	inputs.dir snippetsDir
+	sources {
+		include("**/index.adoc")
+	}
+	baseDirFollowsSourceDir()
+}
+
+asciidoctor.doFirst {
+	delete file('src/main/resources/static/docs')
+}
+
+task copyDocument(type: Copy) {
+	dependsOn asciidoctor
+	from file("build/docs/asciidoc")
+	into file("src/main/resources/static/docs")
+}
+
+bootJar {
+	dependsOn asciidoctor
+	from ("${asciidoctor.outputDir}/html5") {
+		into 'static/docs'
+	}
+}
+
+build {
+	dependsOn copyDocument
+}
+
+clean {
+	delete file('src/main/generated')
 }

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,0 +1,16 @@
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+:sectlinks:
+
+ifndef::snippets[]
+:snippets: ./build/generated-snippets
+endif::[]
+
+= API 문서
+
+include::member.adoc[]
+
+created by zzanzi

--- a/src/docs/asciidoc/member.adoc
+++ b/src/docs/asciidoc/member.adoc
@@ -1,0 +1,19 @@
+== Member APIs
+
+=== 문서화 테스트
+테스트 설명
+
+==== 요청
+HTTP Example
+
+include::{snippets}/member/test/http-request.adoc[]
+
+==== 응답
+Response HTTP Example
+
+*정상*
+include::{snippets}/member/test/http-response.adoc[]
+
+Response Parameters
+
+include::{snippets}/member/test/response-fields.adoc[]

--- a/src/main/java/com/nexters/jjanji/member/api/MemberController.java
+++ b/src/main/java/com/nexters/jjanji/member/api/MemberController.java
@@ -1,6 +1,7 @@
 package com.nexters.jjanji.member.api;
 
 import com.nexters.jjanji.common.auth.MemberContext;
+import com.nexters.jjanji.member.dto.TestDto;
 import com.nexters.jjanji.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,7 +16,7 @@ public class MemberController {
     private final MemberService memberService;
 
     @GetMapping("/test")
-    public Long test() {
-        return MemberContext.getContext();
+    public TestDto test() {
+        return new TestDto(MemberContext.getContext());
     }
 }

--- a/src/main/java/com/nexters/jjanji/member/dto/TestDto.java
+++ b/src/main/java/com/nexters/jjanji/member/dto/TestDto.java
@@ -1,0 +1,12 @@
+package com.nexters.jjanji.member.dto;
+
+import lombok.Data;
+
+@Data
+public class TestDto {
+    private Long memberId;
+
+    public TestDto(Long memberId) {
+        this.memberId = memberId;
+    }
+}

--- a/src/test/java/com/nexters/jjanji/docs/RestDocs.java
+++ b/src/test/java/com/nexters/jjanji/docs/RestDocs.java
@@ -1,0 +1,27 @@
+package com.nexters.jjanji.docs;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.test.web.servlet.setup.MockMvcConfigurer;
+import org.springframework.test.web.servlet.setup.StandaloneMockMvcBuilder;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+
+@ExtendWith(RestDocumentationExtension.class)
+public class RestDocs {
+    private MockMvcConfigurer apply(RestDocumentationContextProvider restDocumentation) {
+        return documentationConfiguration(restDocumentation);
+    }
+
+    protected DefaultMockMvcBuilder getMockMvcBuilder(RestDocumentationContextProvider restDocumentation, WebApplicationContext context) {
+        return MockMvcBuilders.webAppContextSetup(context).apply(apply(restDocumentation));
+    }
+
+    public StandaloneMockMvcBuilder getMockMvcBuilder(RestDocumentationContextProvider restDocumentation, Object... controllers) {
+        return MockMvcBuilders.standaloneSetup(controllers).apply(apply(restDocumentation));
+    }
+}

--- a/src/test/java/com/nexters/jjanji/member/api/MemberControllerTest.java
+++ b/src/test/java/com/nexters/jjanji/member/api/MemberControllerTest.java
@@ -1,0 +1,71 @@
+package com.nexters.jjanji.member.api;
+
+import com.nexters.jjanji.docs.RestDocs;
+import com.nexters.jjanji.member.domain.Member;
+import com.nexters.jjanji.member.domain.MemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@AutoConfigureRestDocs
+@Transactional
+class MemberControllerTest extends RestDocs {
+
+    final static String AUTHORIZATION_HEADER = "Authorization";
+    final static String DEVICE_ID = "DEVICE_ID";
+    MockMvc mockMvc;
+    @Autowired HandlerInterceptor handlerInterceptor;
+    @Autowired MemberRepository memberRepository;
+    @Autowired MemberController memberController;
+
+    @BeforeEach
+    void setUp(RestDocumentationContextProvider restDocumentation) {
+        this.mockMvc = getMockMvcBuilder(restDocumentation, memberController)
+                .addInterceptors(handlerInterceptor)
+                .build();
+        memberRepository.save(Member.builder()
+                .deviceId("DEVICE_ID")
+                .build());
+    }
+
+    @Test
+    @DisplayName("유저 테스트 API - 문서화 테스트")
+    void addPhochak() throws Exception {
+
+        //when, then
+        mockMvc.perform(get("/member/test").header(AUTHORIZATION_HEADER, DEVICE_ID))
+                .andExpect(status().isOk())
+                .andDo(document("member/test",
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(
+                                headerWithName(AUTHORIZATION_HEADER)
+                                        .description("(필수) device id")
+                        ),
+                        responseFields(
+                                fieldWithPath("memberId").type(JsonFieldType.NUMBER).description("응답값")
+                        )
+                ));
+    }
+}


### PR DESCRIPTION
❗️ 이슈 번호
close #8 


📝 구현 내용
(가능한 한 자세히 작성해 주시면 감사하겠습니다!)
rest docs 문서화 설정했습니다.
접속 url: http://localhost:8080/docs/index.html
![스크린샷 2023-07-10 오후 7 19 02](https://github.com/Nexters/zzanji-server/assets/76773202/ab446360-8e8b-4737-9b44-2f0a8b8039c9)


🙇🏻‍♂️ 리뷰어에게 부탁합니다!
(리뷰어에게 부탁하는 말을 작성해주세요. 없다면 지워도 됩니다!)
CICD 파이프라인 개발 시, 문서화까지 잘 작동하는지 확인 부탁드립니다.


💡 참고 자료
(없다면 지워도 됩니다!)