### PR TITLE
feat: 카테고리별 세부 목표 등록 api 구현

### DIFF
--- a/src/docs/asciidoc/challenge.adoc
+++ b/src/docs/asciidoc/challenge.adoc
@@ -27,3 +27,46 @@ Response HTTP Example
 
 *정상*
 include::{snippets}/challenge/participate/POST/http-response.adoc[]
+
+=== 카테고리별 계획 등록
+
+다음 챌린지의 카테고리 계획을 등록합니다.
+
+파라미터로 *'리스트'* 형태의 데이터를 받습니다.
+
+혹시 클라이언트에서 벌크 업데이트 등 최적화 가능성을 고려하여 리스트 형태로 받습니다.
+
+일반적인 경우에, 배열에 하나의 데이터만 넣어도 무방합니다.
+
+==== 발생 가능 예외
+4xx - 아직 챌린지에 참여하지 않았습니다.
+
+==== 현재 지원 카테고리
+
+현재는 다음 카테고리를 지원합니다.
+
+기획 확정 이후에 추가 예정입니다.
+
+|===
+|FOOD |식비
+|TRANSPORTATION |교통비
+|===
+
+==== 요청
+HTTP Example
+
+include::{snippets}/challenge/plan/category/POST/http-request.adoc[]
+
+Request Header
+
+include::{snippets}/challenge/plan/category/POST/request-headers.adoc[]
+
+Request Body
+
+include::{snippets}/challenge/plan/category/POST/request-fields.adoc[]
+
+==== 응답
+Response HTTP Example
+
+*정상*
+include::{snippets}/challenge/plan/category/POST/http-response.adoc[]

--- a/src/main/java/com/nexters/jjanji/domain/challenge/domain/Plan.java
+++ b/src/main/java/com/nexters/jjanji/domain/challenge/domain/Plan.java
@@ -11,6 +11,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -37,4 +38,11 @@ public class Plan {
     @Column(nullable = false, columnDefinition = "bigint default 0")
     private Long categorySpendAmount;
 
+    @Builder
+    public Plan(Participation participation, PlanCategory category, Long categoryGoalAmount) {
+        this.participation = participation;
+        this.category = category;
+        this.categoryGoalAmount = categoryGoalAmount;
+        this.categorySpendAmount = 0L;
+    }
 }

--- a/src/main/java/com/nexters/jjanji/domain/challenge/domain/repository/ParticipationRepository.java
+++ b/src/main/java/com/nexters/jjanji/domain/challenge/domain/repository/ParticipationRepository.java
@@ -10,4 +10,6 @@ import java.util.Optional;
 public interface ParticipationRepository extends JpaRepository<Participation, Long> {
 
     boolean existsByMemberAndChallenge(Member member, Challenge nextChallenge);
+
+    Optional<Participation> findByMemberAndChallenge(Member member, Challenge nextChallenge);
 }

--- a/src/main/java/com/nexters/jjanji/domain/challenge/dto/request/CreateCategoryPlanRequestDto.java
+++ b/src/main/java/com/nexters/jjanji/domain/challenge/dto/request/CreateCategoryPlanRequestDto.java
@@ -1,0 +1,19 @@
+package com.nexters.jjanji.domain.challenge.dto.request;
+
+import com.nexters.jjanji.domain.challenge.specification.PlanCategory;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CreateCategoryPlanRequestDto {
+    private PlanCategory category;
+    private Long goalAmount;
+
+    @Builder
+    public CreateCategoryPlanRequestDto(PlanCategory category, Long goalAmount) {
+        this.category = category;
+        this.goalAmount = goalAmount;
+    }
+}

--- a/src/main/java/com/nexters/jjanji/domain/challenge/presentation/ChallengeController.java
+++ b/src/main/java/com/nexters/jjanji/domain/challenge/presentation/ChallengeController.java
@@ -1,6 +1,7 @@
 package com.nexters.jjanji.domain.challenge.presentation;
 
 import com.nexters.jjanji.domain.challenge.application.ChallengeService;
+import com.nexters.jjanji.domain.challenge.dto.request.CreateCategoryPlanRequestDto;
 import com.nexters.jjanji.domain.challenge.dto.request.ParticipateRequestDto;
 import com.nexters.jjanji.global.auth.MemberContext;
 import jakarta.validation.Valid;
@@ -9,6 +10,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/v1/challenge")
@@ -21,5 +24,11 @@ public class ChallengeController {
     public void participateNextChallenge(@Valid @RequestBody ParticipateRequestDto participateRequestDto) {
         Long memberId = MemberContext.getContext();
         challengeService.participateNextChallenge(memberId, participateRequestDto);
+    }
+
+    @PostMapping("/plan/category")
+    public void addCategoryPlan(@RequestBody List<CreateCategoryPlanRequestDto> createCategoryPlanRequestDtoList) {
+        Long memberId = MemberContext.getContext();
+        challengeService.addCategoryPlan(memberId, createCategoryPlanRequestDtoList);
     }
 }

--- a/src/main/java/com/nexters/jjanji/domain/challenge/specification/PlanCategory.java
+++ b/src/main/java/com/nexters/jjanji/domain/challenge/specification/PlanCategory.java
@@ -1,4 +1,6 @@
 package com.nexters.jjanji.domain.challenge.specification;
 
 public enum PlanCategory {
+    FOOD,
+    TRANSPORTATION
 }

--- a/src/main/java/com/nexters/jjanji/domain/member/application/MemberService.java
+++ b/src/main/java/com/nexters/jjanji/domain/member/application/MemberService.java
@@ -1,0 +1,21 @@
+package com.nexters.jjanji.domain.member.application;
+
+import com.nexters.jjanji.domain.member.domain.Member;
+import com.nexters.jjanji.domain.member.domain.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class MemberService {
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public Member createMember(String deviceId) {
+        Member member = Member.builder()
+                .deviceId(deviceId)
+                .build();
+        return memberRepository.save(member);
+    }
+}

--- a/src/main/java/com/nexters/jjanji/global/auth/DeviceIdAuthInterceptor.java
+++ b/src/main/java/com/nexters/jjanji/global/auth/DeviceIdAuthInterceptor.java
@@ -1,8 +1,8 @@
 package com.nexters.jjanji.global.auth;
 
+import com.nexters.jjanji.domain.member.application.MemberService;
 import com.nexters.jjanji.domain.member.domain.Member;
 import com.nexters.jjanji.domain.member.domain.MemberRepository;
-import com.nexters.jjanji.domain.member.application.MemberService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;

--- a/src/test/java/com/nexters/jjanji/domain/challenge/presentation/ChallengeControllerTest.java
+++ b/src/test/java/com/nexters/jjanji/domain/challenge/presentation/ChallengeControllerTest.java
@@ -2,7 +2,13 @@ package com.nexters.jjanji.domain.challenge.presentation;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nexters.jjanji.docs.RestDocs;
+import com.nexters.jjanji.domain.challenge.domain.Challenge;
+import com.nexters.jjanji.domain.challenge.domain.Participation;
+import com.nexters.jjanji.domain.challenge.domain.repository.ChallengeRepository;
+import com.nexters.jjanji.domain.challenge.domain.repository.ParticipationRepository;
+import com.nexters.jjanji.domain.challenge.dto.request.CreateCategoryPlanRequestDto;
 import com.nexters.jjanji.domain.challenge.dto.request.ParticipateRequestDto;
+import com.nexters.jjanji.domain.challenge.specification.PlanCategory;
 import com.nexters.jjanji.domain.member.domain.Member;
 import com.nexters.jjanji.domain.member.domain.MemberRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -17,6 +23,9 @@ import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
@@ -42,15 +51,20 @@ class ChallengeControllerTest extends RestDocs {
     @Autowired
     MemberRepository memberRepository;
     @Autowired ChallengeController challengeController;
+    @Autowired ParticipationRepository participationRepository;
+    @Autowired ChallengeRepository challengeRepository;
+
+    Long testMemberId;
 
     @BeforeEach
     void setUp(RestDocumentationContextProvider restDocumentation) {
         this.mockMvc = getMockMvcBuilder(restDocumentation, challengeController)
                 .addInterceptors(handlerInterceptor)
                 .build();
-        memberRepository.save(Member.builder()
+        Member member = memberRepository.save(Member.builder()
                 .deviceId("DEVICE_ID")
                 .build());
+        testMemberId = member.getId();
     }
 
     @Test
@@ -75,6 +89,55 @@ class ChallengeControllerTest extends RestDocs {
                         ),
                         requestFields(
                                 fieldWithPath("goalAmount").type(JsonFieldType.NUMBER).description("목표 금액")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("챌린지 API - 카테고리별 목표 등록")
+    void addCategoryPlan() throws Exception {
+        //given
+        Challenge challenge = challengeRepository.save(
+                Challenge.builder()
+                        .startAt(LocalDateTime.now())
+                        .endAt(LocalDateTime.now().plusDays(7))
+                        .build()
+        );
+
+        participationRepository.save(
+                Participation.builder()
+                        .challenge(challenge)
+                        .goalAmount(10000L)
+                        .member(memberRepository.getReferenceById(testMemberId))
+                        .build()
+        );
+
+        List<CreateCategoryPlanRequestDto> request = List.of(
+                CreateCategoryPlanRequestDto.builder()
+                        .category(PlanCategory.TRANSPORTATION)
+                        .goalAmount(10000L)
+                        .build(),
+                CreateCategoryPlanRequestDto.builder()
+                        .category(PlanCategory.FOOD)
+                        .goalAmount(200000L)
+                        .build()
+        );
+
+        //when, then
+        mockMvc.perform(post("/v1/challenge/plan/category")
+                .header(AUTHORIZATION_HEADER, DEVICE_ID)
+                .header("Content-Type", "application/json")
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andDo(document("challenge/plan/category/POST",
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(
+                                headerWithName(AUTHORIZATION_HEADER)
+                                        .description("(필수) device id")
+                        ),
+                        requestFields(
+                                fieldWithPath("[].category").type(JsonFieldType.STRING).description("카테고리"),
+                                fieldWithPath("[].goalAmount").type(JsonFieldType.NUMBER).description("목표 금액")
                         )
                 ));
     }


### PR DESCRIPTION
❗️ 이슈 번호
close #14 


📝 구현 내용
- 카테고리별 세부 목표 등록 api 구현
  - 여러개 벌크 요청 가능하게 설계
- 카테고리 정의는 기획 반영 정확하게 진행된 이후 진행


💡 참고 자료
(없다면 지워도 됩니다!)