### PR TITLE
feat: 다음 챌린지의 총 목표 금액 수정 구현

### DIFF
--- a/src/docs/asciidoc/challenge.adoc
+++ b/src/docs/asciidoc/challenge.adoc
@@ -99,3 +99,29 @@ Response HTTP Example
 
 *정상*
 include::{snippets}/challenge/plan/category/POST/http-response.adoc[]
+
+=== 다음 챌린지의 총 목표 금액 수정
+
+다음 챌린지의 다음 챌린지의 총 목표 금액 수정합니다.
+
+==== 발생 가능 예외
+4xx - 아직 챌린지에 참여하지 않았습니다.
+
+==== 요청
+HTTP Example
+
+include::{snippets}/challenge/participate/goalAmount/PUT/http-request.adoc[]
+
+Request Header
+
+include::{snippets}/challenge/participate/goalAmount/PUT/request-headers.adoc[]
+
+Request Body
+
+include::{snippets}/challenge/participate/goalAmount/PUT/request-fields.adoc[]
+
+==== 응답
+Response HTTP Example
+
+*정상*
+include::{snippets}/challenge/participate/goalAmount/PUT/http-response.adoc[]

--- a/src/main/java/com/nexters/jjanji/domain/challenge/application/ChallengeService.java
+++ b/src/main/java/com/nexters/jjanji/domain/challenge/application/ChallengeService.java
@@ -9,6 +9,7 @@ import com.nexters.jjanji.domain.challenge.domain.repository.ParticipationReposi
 import com.nexters.jjanji.domain.challenge.domain.repository.PlanRepository;
 import com.nexters.jjanji.domain.challenge.dto.request.ParticipateRequestDto;
 import com.nexters.jjanji.domain.challenge.dto.request.CreateCategoryPlanRequestDto;
+import com.nexters.jjanji.domain.challenge.dto.request.UpdateGoalAmountRequestDto;
 import com.nexters.jjanji.domain.challenge.dto.response.ParticipationResponseDto;
 import com.nexters.jjanji.domain.challenge.specification.ChallengeState;
 import com.nexters.jjanji.domain.member.domain.Member;
@@ -103,5 +104,14 @@ public class ChallengeService {
             participationResponseDto.setPlanList(planList);
         });
         return participateList;
+    }
+
+    @Transactional
+    public void updateTotalGoalAmount(Long memberId, UpdateGoalAmountRequestDto updateGoalAmountRequestDto) {
+        Member member = memberRepository.getReferenceById(memberId);
+        Challenge nextChallenge = challengeRepository.findNextChallenge();
+        Participation participation = participationRepository.findByMemberAndChallenge(member, nextChallenge)
+                .orElseThrow(() -> new IllegalStateException("아직 챌린지에 참여하지 않았습니다."));
+        participation.updateGoalAmount(updateGoalAmountRequestDto.getGoalAmount());
     }
 }

--- a/src/main/java/com/nexters/jjanji/domain/challenge/domain/Participation.java
+++ b/src/main/java/com/nexters/jjanji/domain/challenge/domain/Participation.java
@@ -49,4 +49,8 @@ public class Participation {
     public void updateCurrentAmount(Long amount) {
         this.currentAmount += amount;
     }
+
+    public void updateGoalAmount(Long goalAmount) {
+        this.goalAmount = goalAmount;
+    }
 }

--- a/src/main/java/com/nexters/jjanji/domain/challenge/dto/request/UpdateGoalAmountRequestDto.java
+++ b/src/main/java/com/nexters/jjanji/domain/challenge/dto/request/UpdateGoalAmountRequestDto.java
@@ -1,0 +1,16 @@
+package com.nexters.jjanji.domain.challenge.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UpdateGoalAmountRequestDto {
+    private Long goalAmount;
+
+    @Builder
+    public UpdateGoalAmountRequestDto(Long goalAmount) {
+        this.goalAmount = goalAmount;
+    }
+}

--- a/src/main/java/com/nexters/jjanji/domain/challenge/presentation/ChallengeController.java
+++ b/src/main/java/com/nexters/jjanji/domain/challenge/presentation/ChallengeController.java
@@ -3,12 +3,14 @@ package com.nexters.jjanji.domain.challenge.presentation;
 import com.nexters.jjanji.domain.challenge.application.ChallengeService;
 import com.nexters.jjanji.domain.challenge.dto.request.CreateCategoryPlanRequestDto;
 import com.nexters.jjanji.domain.challenge.dto.request.ParticipateRequestDto;
+import com.nexters.jjanji.domain.challenge.dto.request.UpdateGoalAmountRequestDto;
 import com.nexters.jjanji.domain.challenge.dto.response.ParticipationResponseDto;
 import com.nexters.jjanji.global.auth.MemberContext;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -27,6 +29,12 @@ public class ChallengeController {
     public List<ParticipationResponseDto> getParticipateList(@RequestParam(required = false) Long cursor, @RequestParam Long size) {
         Long memberId = MemberContext.getContext();
         return challengeService.getParticipateList(memberId, cursor, size);
+    }
+
+    @PutMapping("/participate/goalAmount")
+    public void updateGoalAmount(@RequestBody UpdateGoalAmountRequestDto updateGoalAmountRequestDto) {
+        Long memberId = MemberContext.getContext();
+        challengeService.updateTotalGoalAmount(memberId, updateGoalAmountRequestDto);
     }
 
     @PostMapping("/participate")

--- a/src/test/java/com/nexters/jjanji/domain/challenge/application/ChallengeServiceTest.java
+++ b/src/test/java/com/nexters/jjanji/domain/challenge/application/ChallengeServiceTest.java
@@ -7,6 +7,7 @@ import com.nexters.jjanji.domain.challenge.domain.repository.ParticipationReposi
 import com.nexters.jjanji.domain.challenge.domain.repository.PlanRepository;
 import com.nexters.jjanji.domain.challenge.dto.request.CreateCategoryPlanRequestDto;
 import com.nexters.jjanji.domain.challenge.dto.request.ParticipateRequestDto;
+import com.nexters.jjanji.domain.challenge.dto.request.UpdateGoalAmountRequestDto;
 import com.nexters.jjanji.domain.challenge.specification.PlanCategory;
 import com.nexters.jjanji.domain.member.domain.MemberRepository;
 import org.assertj.core.api.Assertions;
@@ -128,6 +129,20 @@ class ChallengeServiceTest {
         Assertions.assertThatThrownBy(() -> {
             challengeService.addCategoryPlan(1L, request);
         }).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    @DisplayName("전체 목표 금액 수정 - 성공")
+    void updateTotalGoalAmount() {
+        // given
+        Participation mockParticipation = new Participation();
+        UpdateGoalAmountRequestDto updateGoalAmountRequestDto = UpdateGoalAmountRequestDto.builder()
+                .goalAmount(10000L)
+                .build();
+        given(participationRepository.findByMemberAndChallenge(any(), any())).willReturn(Optional.of(mockParticipation));
+
+        // when, then
+        challengeService.updateTotalGoalAmount(1L, updateGoalAmountRequestDto);
     }
 
 }


### PR DESCRIPTION
❗️ 이슈 번호
close #30 


📝 구현 내용
(가능한 한 자세히 작성해 주시면 감사하겠습니다!)

다음 챌린지의 총 목표 금액 수정합니다.

파라미터로 챌린지 id 받을까 하다가, 어차피 다음 챌린지만 변경 가능해서 금액만 받는 로직으로 적용합니다.

