### PR TITLE
feat: 카테고리 별 지출 내역 수정 API 구현

### DIFF
--- a/src/docs/asciidoc/spending.adoc
+++ b/src/docs/asciidoc/spending.adoc
@@ -4,7 +4,7 @@
 카테고리별 소비 내역을 입력합니다.
 
 ==== 발생 가능한 예외
-400 - 카테고리 정보가 존재하지 않습니다. planId = {planId}
+- 400 : 카테고리 정보가 존재하지 않습니다. planId = {planId}
 
 ==== 요청
 *HTTP Request Example*
@@ -28,14 +28,13 @@ include::{snippets}/challenge//plan/spending/POST/http-response.adoc[]
 === 소비 내역 수정
 카테고리별 소비 내역을 수정합니다.
 
+- 종료되거나 아직 시작하지 않은 챌린지의 소비 내역 수정은 불가능 합니다.
+
 ==== 발생 가능한 예외
-400 - 카테고리에 해당하는 챌린지 정보가 없습니다. planId = {planId}
-
-400 - 소비내역 추가 및 변경이 가능한 기간이 아닙니다. spendingId = {spendingId}
-
-400 - 카테고리 정보가 존재하지 않습니다. planId = {planId}
-
-400 - 소비내역 정보가 존재하지 않습니다. spendingId = {spendingId}
+- 400 : 카테고리에 해당하는 챌린지 정보가 없습니다. planId = {planId}
+- 400 : 소비내역 추가 및 변경이 가능한 기간이 아닙니다. spendingId = {spendingId}
+- 400 : 카테고리 정보가 존재하지 않습니다. planId = {planId}
+- 400 : 소비내역 정보가 존재하지 않습니다. spendingId = {spendingId}
 
 ==== 요청
 *HTTP Request Example*
@@ -59,8 +58,10 @@ include::{snippets}/challenge//plan/spending/PUT/http-response.adoc[]
 === 카테고리별 소비 내역 리스트 조회(무한스크롤)
 카테고리별 소비 내역 리스트를 조회합니다.
 
+- 가장 최신 소비내역 부터 보여줍니다.
+
 ==== 발생 가능한 예외
-400 - 카테고리 정보가 존재하지 않습니다. planId = {planId}
+- 400 : 카테고리 정보가 존재하지 않습니다. planId = {planId}
 
 ==== 요청
 *HTTP Request Example*

--- a/src/docs/asciidoc/spending.adoc
+++ b/src/docs/asciidoc/spending.adoc
@@ -4,7 +4,7 @@
 카테고리별 소비 내역을 입력합니다.
 
 ==== 발생 가능한 예외
-400 - 계획된 카테고리 정보가 없습니다.
+400 - 카테고리 정보가 존재하지 않습니다. planId = {planId}
 
 ==== 요청
 *HTTP Request Example*
@@ -29,13 +29,13 @@ include::{snippets}/challenge//plan/spending/POST/http-response.adoc[]
 카테고리별 소비 내역을 수정합니다.
 
 ==== 발생 가능한 예외
-400 - 카테고리에 해당하는 챌린지 정보가 없습니다.
+400 - 카테고리에 해당하는 챌린지 정보가 없습니다. planId = {planId}
 
-400 - 계획된 카테고리 정보가 없습니다.
+400 - 소비내역 추가 및 변경이 가능한 기간이 아닙니다. spendingId = {spendingId}
 
-400 - 소비 내역 추가 및 변경이 가능한 기간이 아닙니다.
+400 - 카테고리 정보가 존재하지 않습니다. planId = {planId}
 
-400 - 소비 내역 정보가 존재하지 않습니다.
+400 - 소비내역 정보가 존재하지 않습니다. spendingId = {spendingId}
 
 ==== 요청
 *HTTP Request Example*
@@ -60,7 +60,7 @@ include::{snippets}/challenge//plan/spending/PUT/http-response.adoc[]
 카테고리별 소비 내역 리스트를 조회합니다.
 
 ==== 발생 가능한 예외
-400 - 계획된 카테고리 정보가 없습니다.
+400 - 카테고리 정보가 존재하지 않습니다. planId = {planId}
 
 ==== 요청
 *HTTP Request Example*

--- a/src/docs/asciidoc/spending.adoc
+++ b/src/docs/asciidoc/spending.adoc
@@ -25,6 +25,36 @@ include::{snippets}/challenge/plan/spending/POST/request-fields.adoc[]
 *200*
 include::{snippets}/challenge//plan/spending/POST/http-response.adoc[]
 
+=== 소비 내역 수정
+카테고리별 소비 내역을 수정합니다.
+
+==== 발생 가능한 예외
+400 - 카테고리에 해당하는 챌린지 정보가 없습니다.
+
+400 - 계획된 카테고리 정보가 없습니다.
+
+400 - 소비 내역 추가 및 변경이 가능한 기간이 아닙니다.
+
+400 - 소비 내역 정보가 존재하지 않습니다.
+
+==== 요청
+*HTTP Request Example*
+include::{snippets}/challenge/plan/spending/PUT/http-request.adoc[]
+
+*Request Header*
+include::{snippets}/challenge/plan/spending/PUT/request-headers.adoc[]
+
+*Request Path*
+include::{snippets}/challenge/plan/spending/PUT/path-parameters.adoc[]
+
+*Request Body*
+include::{snippets}/challenge/plan/spending/PUT/request-fields.adoc[]
+
+===== 응답
+*Http Response Example*
+
+*200*
+include::{snippets}/challenge//plan/spending/PUT/http-response.adoc[]
 
 === 카테고리별 소비 내역 리스트 조회(무한스크롤)
 카테고리별 소비 내역 리스트를 조회합니다.

--- a/src/docs/asciidoc/spending.adoc
+++ b/src/docs/asciidoc/spending.adoc
@@ -55,7 +55,7 @@ include::{snippets}/challenge/plan/spending/PUT/request-fields.adoc[]
 *200*
 include::{snippets}/challenge//plan/spending/PUT/http-response.adoc[]
 
-=== 카테고리별 소비 내역 리스트 조회(무한스크롤)
+=== 카테고리별 소비 내역 리스트 조회(페이징)
 카테고리별 소비 내역 리스트를 조회합니다.
 
 - 가장 최신 소비내역 부터 보여줍니다.

--- a/src/main/java/com/nexters/jjanji/domain/challenge/application/SpendingHistoryService.java
+++ b/src/main/java/com/nexters/jjanji/domain/challenge/application/SpendingHistoryService.java
@@ -59,30 +59,36 @@ public class SpendingHistoryService {
 
     @Transactional
     public Long editSpendingHistory(Long planId, Long spendingId, SpendingEditDto dto){
-        //현재 챌린지일 경우에만 소비 내역 수정 가능.
-        Challenge findChallenge = challengeRepository.findChallengeByPlanId(planId)
-                .orElseThrow(() -> new PlanChallengeNotFoundException(planId));
+        Challenge findChallenge = validAndGetChallengeByPlanId(planId);
+        //현재 챌린지 일 경우에만 소비 내역 수정 가능.
         if(!findChallenge.isOpenedChallenge()){
             throw new SpendingPeriodInvalidException(spendingId);
         }
 
-        Plan findPlan = planRepository.findById(planId)
-                .orElseThrow(() -> new PlanNotFoundException(planId));
+        Plan findPlan = validAndGetPlan(planId);
 
         //소비 내역 수정
-        SpendingHistory findSpending = spendingHistoryRepository.findById(spendingId)
-                .orElseThrow(() -> new SpendingNotFoundExcpetion(spendingId));
+        SpendingHistory findSpending = validAndGetSpendingHistory(spendingId);
         final Long newCategorySpendAmount = findPlan.getCategorySpendAmount() - findSpending.getSpendAmount() + dto.getSpendAmount();
         findSpending.updateSpending(dto.getTitle(), dto.getMemo(), dto.getSpendAmount());
 
-        //카테고리 "categorySpendAmount" 필드 업데이트
+        //카테고리 필드 업데이트
         findPlan.updateCategorySpendAmount(newCategorySpendAmount);
 
         return findSpending.getId();
     }
 
     private Plan validAndGetPlan(Long planId){
-        return planRepository.findById(planId).orElseThrow(() -> new PlanNotFoundException(planId));
+        return planRepository.findById(planId)
+                .orElseThrow(() -> new PlanNotFoundException(planId));
+    }
+    private Challenge validAndGetChallengeByPlanId(Long planId){
+        return challengeRepository.findChallengeByPlanId(planId)
+                .orElseThrow(() -> new PlanChallengeNotFoundException(planId));
+    }
+    private SpendingHistory validAndGetSpendingHistory(Long spendingId){
+        return spendingHistoryRepository.findById(spendingId)
+                .orElseThrow(() -> new SpendingNotFoundExcpetion(spendingId));
     }
 }
 

--- a/src/main/java/com/nexters/jjanji/domain/challenge/application/SpendingHistoryService.java
+++ b/src/main/java/com/nexters/jjanji/domain/challenge/application/SpendingHistoryService.java
@@ -1,11 +1,17 @@
 package com.nexters.jjanji.domain.challenge.application;
 
+import com.nexters.jjanji.domain.challenge.domain.Challenge;
 import com.nexters.jjanji.domain.challenge.domain.Plan;
 import com.nexters.jjanji.domain.challenge.domain.SpendingHistory;
+import com.nexters.jjanji.domain.challenge.domain.repository.ChallengeRepository;
 import com.nexters.jjanji.domain.challenge.domain.repository.PlanRepository;
 import com.nexters.jjanji.domain.challenge.domain.repository.SpendingHistoryRepository;
+import com.nexters.jjanji.domain.challenge.dto.request.SpendingEditDto;
 import com.nexters.jjanji.domain.challenge.dto.request.SpendingSaveDto;
-import com.nexters.jjanji.global.exception.NotExistPlanException;
+import com.nexters.jjanji.global.exception.PlanNotFoundException;
+import com.nexters.jjanji.global.exception.PlanChallengeNotFoundException;
+import com.nexters.jjanji.global.exception.SpendingNotFoundExcpetion;
+import com.nexters.jjanji.global.exception.SpendingPeriodInvalidException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,11 +20,12 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class SpendingHistoryService {
+    private final ChallengeRepository challengeRepository;
     private final PlanRepository planRepository;
     private final SpendingHistoryRepository spendingHistoryRepository;
     @Transactional
     public void addSpendingHistory(Long planId, SpendingSaveDto dto){
-        Plan findPlan = planRepository.findById(planId).orElseThrow(() -> new NotExistPlanException(planId));
+        Plan findPlan = planRepository.findById(planId).orElseThrow(() -> new PlanNotFoundException(planId));
 
         SpendingHistory createSpending = SpendingHistory.builder()
                 .title(dto.getTitle())
@@ -27,6 +34,30 @@ public class SpendingHistoryService {
                 .plan(findPlan)
                 .build();
         spendingHistoryRepository.save(createSpending);
+    }
+
+    @Transactional
+    public Long editSpendingHistory(Long planId, Long spendingId, SpendingEditDto dto){
+        //현재 챌린지일 경우에만 소비 내역 수정 가능.
+        Challenge findChallenge = challengeRepository.findChallengeByPlanId(planId)
+                .orElseThrow(() -> new PlanChallengeNotFoundException(planId));
+        if(!findChallenge.isOpenedChallenge()){
+            throw new SpendingPeriodInvalidException(spendingId);
+        }
+
+        Plan findPlan = planRepository.findById(planId)
+                .orElseThrow(() -> new PlanNotFoundException(planId));
+
+        //소비 내역 수정
+        SpendingHistory findSpending = spendingHistoryRepository.findById(spendingId)
+                .orElseThrow(() -> new SpendingNotFoundExcpetion(spendingId));
+        final Long newCategorySpendAmount = findPlan.getCategorySpendAmount() - findSpending.getSpendAmount() + dto.getSpendAmount();
+        findSpending.updateSpending(dto.getTitle(), dto.getMemo(), dto.getSpendAmount());
+
+        //카테고리 "categorySpendAmount" 필드 업데이트
+        findPlan.updateCategorySpendAmount(newCategorySpendAmount);
+
+        return findSpending.getId();
     }
 }
 

--- a/src/main/java/com/nexters/jjanji/domain/challenge/application/SpendingHistoryService.java
+++ b/src/main/java/com/nexters/jjanji/domain/challenge/application/SpendingHistoryService.java
@@ -57,7 +57,7 @@ public class SpendingHistoryService {
     }
 
     @Transactional
-    public Long editSpendingHistory(Long planId, Long spendingId, SpendingEditDto dto){
+    public void editSpendingHistory(Long planId, Long spendingId, SpendingEditDto dto){
         Challenge findChallenge = validAndGetChallengeByPlanId(planId);
         //현재 챌린지 일 경우에만 소비 내역 수정 가능.
         if(!findChallenge.isOpenedChallenge()){
@@ -73,8 +73,6 @@ public class SpendingHistoryService {
 
         //카테고리 필드 업데이트
         findPlan.updateCategorySpendAmount(newCategorySpendAmount);
-
-        return findSpending.getId();
     }
 
     private Plan validAndGetPlan(Long planId){

--- a/src/main/java/com/nexters/jjanji/domain/challenge/domain/Challenge.java
+++ b/src/main/java/com/nexters/jjanji/domain/challenge/domain/Challenge.java
@@ -74,4 +74,8 @@ public class Challenge {
         state = ChallengeState.OPENED;
     }
 
+    public Boolean isOpenedChallenge(){
+        return state.equals(ChallengeState.OPENED);
+    }
+
 }

--- a/src/main/java/com/nexters/jjanji/domain/challenge/domain/Plan.java
+++ b/src/main/java/com/nexters/jjanji/domain/challenge/domain/Plan.java
@@ -49,4 +49,5 @@ public class Plan {
     public void plusCategorySpendAmount(Long amount){
         this.categorySpendAmount += amount;
     }
+    public void updateCategorySpendAmount(Long Amount){this.categorySpendAmount = Amount;}
 }

--- a/src/main/java/com/nexters/jjanji/domain/challenge/domain/SpendingHistory.java
+++ b/src/main/java/com/nexters/jjanji/domain/challenge/domain/SpendingHistory.java
@@ -45,4 +45,9 @@ public class SpendingHistory extends BaseTime {
         this.spendAmount = spendAmount;
     }
 
+    public void updateSpending(String title, String memo, Long spendAmount){
+        this.title = title;
+        this.memo = memo;
+        this.spendAmount = spendAmount;
+    }
 }

--- a/src/main/java/com/nexters/jjanji/domain/challenge/domain/repository/ChallengeRepository.java
+++ b/src/main/java/com/nexters/jjanji/domain/challenge/domain/repository/ChallengeRepository.java
@@ -13,4 +13,10 @@ public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
     Challenge findNextChallenge();
 
     Optional<Challenge> findChallengeByState(ChallengeState state);
+
+    @Query("select distinct c " +
+            "from Plan pl " +
+            "join pl.participation pa on pl.id=:planId " +
+            "join pa.challenge c")
+    Optional<Challenge> findChallengeByPlanId(Long planId);
 }

--- a/src/main/java/com/nexters/jjanji/domain/challenge/domain/repository/ChallengeRepository.java
+++ b/src/main/java/com/nexters/jjanji/domain/challenge/domain/repository/ChallengeRepository.java
@@ -14,7 +14,7 @@ public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
 
     Optional<Challenge> findChallengeByState(ChallengeState state);
 
-    @Query("select distinct c " +
+    @Query("select c " +
             "from Plan pl " +
             "join pl.participation pa on pl.id=:planId " +
             "join pa.challenge c")

--- a/src/main/java/com/nexters/jjanji/domain/challenge/dto/request/SpendingEditDto.java
+++ b/src/main/java/com/nexters/jjanji/domain/challenge/dto/request/SpendingEditDto.java
@@ -1,5 +1,7 @@
 package com.nexters.jjanji.domain.challenge.dto.request;
 
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotEmpty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,7 +11,9 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class SpendingEditDto {
 
+    @NotEmpty
     private String title;
     private String memo;
+    @Min(value = 1)
     private Long spendAmount;
 }

--- a/src/main/java/com/nexters/jjanji/domain/challenge/dto/request/SpendingEditDto.java
+++ b/src/main/java/com/nexters/jjanji/domain/challenge/dto/request/SpendingEditDto.java
@@ -1,0 +1,15 @@
+package com.nexters.jjanji.domain.challenge.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SpendingEditDto {
+
+    private String title;
+    private String memo;
+    private Long spendAmount;
+}

--- a/src/main/java/com/nexters/jjanji/domain/challenge/presentation/SpendingHistoryController.java
+++ b/src/main/java/com/nexters/jjanji/domain/challenge/presentation/SpendingHistoryController.java
@@ -1,6 +1,7 @@
 package com.nexters.jjanji.domain.challenge.presentation;
 
 import com.nexters.jjanji.domain.challenge.application.SpendingHistoryService;
+import com.nexters.jjanji.domain.challenge.dto.request.SpendingEditDto;
 import com.nexters.jjanji.domain.challenge.dto.request.SpendingSaveDto;
 import com.nexters.jjanji.domain.challenge.dto.response.SpendingDetailResponse;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +28,12 @@ public class SpendingHistoryController {
                                                                @RequestParam Integer size){
         SpendingDetailResponse spendingList = spendingHistoryService.findSpendingList(planId, cursorId, PageRequest.ofSize(size));
         return ResponseEntity.ok(spendingList);
+    }
+
+    @PutMapping("/{planId}/spending/{spendingId}")
+    public ResponseEntity editSpending(@PathVariable Long planId, @PathVariable Long spendingId, @RequestBody SpendingEditDto dto){
+        spendingHistoryService.editSpendingHistory(planId, spendingId, dto);
+        return ResponseEntity.ok().build();
     }
 
 }

--- a/src/main/java/com/nexters/jjanji/domain/challenge/presentation/SpendingHistoryController.java
+++ b/src/main/java/com/nexters/jjanji/domain/challenge/presentation/SpendingHistoryController.java
@@ -4,6 +4,7 @@ import com.nexters.jjanji.domain.challenge.application.SpendingHistoryService;
 import com.nexters.jjanji.domain.challenge.dto.request.SpendingEditDto;
 import com.nexters.jjanji.domain.challenge.dto.request.SpendingSaveDto;
 import com.nexters.jjanji.domain.challenge.dto.response.SpendingDetailResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -31,7 +32,7 @@ public class SpendingHistoryController {
     }
 
     @PutMapping("/{planId}/spending/{spendingId}")
-    public ResponseEntity editSpending(@PathVariable Long planId, @PathVariable Long spendingId, @RequestBody SpendingEditDto dto){
+    public ResponseEntity editSpending(@PathVariable Long planId, @PathVariable Long spendingId, @Valid @RequestBody SpendingEditDto dto){
         spendingHistoryService.editSpendingHistory(planId, spendingId, dto);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/nexters/jjanji/global/exception/PlanChallengeNotFoundException.java
+++ b/src/main/java/com/nexters/jjanji/global/exception/PlanChallengeNotFoundException.java
@@ -1,0 +1,14 @@
+package com.nexters.jjanji.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class PlanChallengeNotFoundException extends BaseException{
+
+    public PlanChallengeNotFoundException(Long planId){
+        super(
+                String.format("카테고리에 해당하는 챌린지 정보가 없습니다. planId = {%d}", planId),
+                "카테고리에 해당하는 챌린지 정보가 없습니다.",
+                HttpStatus.BAD_REQUEST
+        );
+    }
+}

--- a/src/main/java/com/nexters/jjanji/global/exception/PlanNotFoundException.java
+++ b/src/main/java/com/nexters/jjanji/global/exception/PlanNotFoundException.java
@@ -4,9 +4,9 @@ import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Getter
-public class NotExistPlanException extends BaseException{
+public class PlanNotFoundException extends BaseException{
 
-    public NotExistPlanException(Long planId) {
+    public PlanNotFoundException(Long planId) {
         super(
                 String.format("해당 카테고리가 존재하지 않습니다. Id = {%d}", planId),
                 "계획된 카테고리 정보가 없습니다.",

--- a/src/main/java/com/nexters/jjanji/global/exception/PlanNotFoundException.java
+++ b/src/main/java/com/nexters/jjanji/global/exception/PlanNotFoundException.java
@@ -9,7 +9,7 @@ public class PlanNotFoundException extends BaseException{
     public PlanNotFoundException(Long planId) {
         super(
                 HttpStatus.NOT_FOUND,
-                String.format("해당 카테고리가 존재하지 않습니다. Id = {%d}", planId)
+                String.format("카테고리 정보가 존재하지 않습니다. planId = {%d}", planId)
         );
 
     }

--- a/src/main/java/com/nexters/jjanji/global/exception/SpendingNotFoundExcpetion.java
+++ b/src/main/java/com/nexters/jjanji/global/exception/SpendingNotFoundExcpetion.java
@@ -7,7 +7,7 @@ public class SpendingNotFoundExcpetion extends BaseException{
     public SpendingNotFoundExcpetion(Long spendingNo){
         super(
                 HttpStatus.BAD_REQUEST,
-                String.format("소비내역이 존재하지 않습니다. spendId = {%d}", spendingNo)
+                String.format("소비내역 정보가 존재하지 않습니다. spendingId = {%d}", spendingNo)
         );
     }
 }

--- a/src/main/java/com/nexters/jjanji/global/exception/SpendingNotFoundExcpetion.java
+++ b/src/main/java/com/nexters/jjanji/global/exception/SpendingNotFoundExcpetion.java
@@ -1,0 +1,14 @@
+package com.nexters.jjanji.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class SpendingNotFoundExcpetion extends BaseException{
+
+    public SpendingNotFoundExcpetion(Long spendingNo){
+        super(
+                String.format("해당 소비내역이 존재하지 않습니다. spendId = {%d}", spendingNo),
+                "소비 내역 정보가 존재하지 않습니다.",
+                HttpStatus.BAD_REQUEST
+        );
+    }
+}

--- a/src/main/java/com/nexters/jjanji/global/exception/SpendingPeriodInvalidException.java
+++ b/src/main/java/com/nexters/jjanji/global/exception/SpendingPeriodInvalidException.java
@@ -1,0 +1,14 @@
+package com.nexters.jjanji.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class SpendingPeriodInvalidException extends BaseException{
+
+    public SpendingPeriodInvalidException(Long spendingId){
+        super(
+                String.format("유효하지 않은 소비 내역 변경 가능 기간, spendingId = {%d}", spendingId),
+                "소비 내역 추가 및 변경이 가능한 기간이 아닙니다.",
+                HttpStatus.BAD_REQUEST
+        );
+    }
+}

--- a/src/main/java/com/nexters/jjanji/global/exception/SpendingPeriodInvalidException.java
+++ b/src/main/java/com/nexters/jjanji/global/exception/SpendingPeriodInvalidException.java
@@ -7,7 +7,7 @@ public class SpendingPeriodInvalidException extends BaseException{
     public SpendingPeriodInvalidException(Long spendingId){
         super(
                 HttpStatus.BAD_REQUEST,
-                String.format("소비 내역 추가 및 변경이 가능한 기간이 아닙니다. spendingId = {%d}", spendingId)
+                String.format("소비내역 추가 및 변경이 가능한 기간이 아닙니다. spendingId = {%d}", spendingId)
         );
     }
 }

--- a/src/main/java/com/nexters/jjanji/global/exception/exhandler/BaseExControllerAdvice.java
+++ b/src/main/java/com/nexters/jjanji/global/exception/exhandler/BaseExControllerAdvice.java
@@ -1,6 +1,6 @@
 package com.nexters.jjanji.global.exception.exhandler;
 
-import com.nexters.jjanji.global.exception.NotExistPlanException;
+import com.nexters.jjanji.global.exception.PlanNotFoundException;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -10,8 +10,8 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice(annotations = RestController.class)
 public class BaseExControllerAdvice {
 
-    @ExceptionHandler(NotExistPlanException.class)
-    public String NotExistPlan(NotExistPlanException e, HttpServletResponse response){
+    @ExceptionHandler(PlanNotFoundException.class)
+    public String NotExistPlan(PlanNotFoundException e, HttpServletResponse response){
         response.setStatus(e.getStatus().value());
 
         log.info(e.getMessage());

--- a/src/test/java/com/nexters/jjanji/domain/challenge/application/SpendingHistoryServiceTest.java
+++ b/src/test/java/com/nexters/jjanji/domain/challenge/application/SpendingHistoryServiceTest.java
@@ -5,7 +5,7 @@ import com.nexters.jjanji.domain.challenge.domain.repository.PlanRepository;
 import com.nexters.jjanji.domain.challenge.domain.repository.SpendingHistoryRepository;
 import com.nexters.jjanji.domain.challenge.dto.request.SpendingSaveDto;
 import com.nexters.jjanji.domain.challenge.specification.PlanCategory;
-import com.nexters.jjanji.global.exception.NotExistPlanException;
+import com.nexters.jjanji.global.exception.PlanNotFoundException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -54,6 +54,6 @@ class SpendingHistoryServiceTest {
         //when & then
         assertThatThrownBy(() -> {
             spendingHistoryService.addSpendingHistory(1L, saveDto);
-        }).isInstanceOf(NotExistPlanException.class);
+        }).isInstanceOf(PlanNotFoundException.class);
     }
 }

--- a/src/test/java/com/nexters/jjanji/domain/challenge/application/SpendingHistoryServiceTest.java
+++ b/src/test/java/com/nexters/jjanji/domain/challenge/application/SpendingHistoryServiceTest.java
@@ -136,7 +136,7 @@ class SpendingHistoryServiceTest {
         final SpendingEditDto dto = new SpendingEditDto("엔제리너스", "부모님", 1000L);
 
         //when
-        Long spendingId = spendingHistoryService.editSpendingHistory(1L, 1L, dto);
+        spendingHistoryService.editSpendingHistory(1L, 1L, dto);
 
         //then
         verify(challengeRepository, times(1)).findChallengeByPlanId(1L);

--- a/src/test/java/com/nexters/jjanji/domain/challenge/application/SpendingHistoryServiceTest.java
+++ b/src/test/java/com/nexters/jjanji/domain/challenge/application/SpendingHistoryServiceTest.java
@@ -1,13 +1,17 @@
 package com.nexters.jjanji.domain.challenge.application;
 
+import com.nexters.jjanji.domain.challenge.domain.Challenge;
 import com.nexters.jjanji.domain.challenge.domain.Plan;
 import com.nexters.jjanji.domain.challenge.domain.SpendingHistory;
+import com.nexters.jjanji.domain.challenge.domain.repository.ChallengeRepository;
 import com.nexters.jjanji.domain.challenge.domain.repository.PlanRepository;
 import com.nexters.jjanji.domain.challenge.domain.repository.SpendingHistoryRepository;
+import com.nexters.jjanji.domain.challenge.dto.request.SpendingEditDto;
 import com.nexters.jjanji.domain.challenge.dto.request.SpendingSaveDto;
 import com.nexters.jjanji.domain.challenge.dto.response.SpendingDetailResponse;
 import com.nexters.jjanji.domain.challenge.specification.PlanCategory;
 import com.nexters.jjanji.global.exception.PlanNotFoundException;
+import com.nexters.jjanji.global.exception.SpendingPeriodInvalidException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -17,6 +21,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.SliceImpl;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -32,6 +38,7 @@ class SpendingHistoryServiceTest {
 
     @Mock PlanRepository planRepository;
     @Mock SpendingHistoryRepository spendingHistoryRepository;
+    @Mock ChallengeRepository challengeRepository;
     @InjectMocks SpendingHistoryService spendingHistoryService;
 
     @Test
@@ -102,4 +109,59 @@ class SpendingHistoryServiceTest {
         verify(spendingHistoryRepository, times(1)).findCursorSliceByPlan(plan, 1L, pageRequest);
     }
 
+    @Test
+    @DisplayName("지출 내역 수정에 성공하다.")
+    void editSpendingHistory(){
+        //given
+        final Challenge challenge = mock(Challenge.class);
+        final Plan plan = mock(Plan.class);
+        final SpendingHistory spending = mock(SpendingHistory.class);
+        final Long categorySpendAmount = 5000L;
+        final Long spendAmount = 3000L;
+
+        given(challengeRepository.findChallengeByPlanId(1L))
+                .willReturn(Optional.of(challenge));
+        given(planRepository.findById(1L))
+                .willReturn(Optional.of(plan));
+        given(spendingHistoryRepository.findById(1L))
+                .willReturn(Optional.of(spending));
+
+        given(challenge.isOpenedChallenge())
+                .willReturn(true);
+        given(plan.getCategorySpendAmount())
+                .willReturn(categorySpendAmount);
+        given(spending.getSpendAmount())
+                .willReturn(spendAmount);
+
+        final SpendingEditDto dto = new SpendingEditDto("엔제리너스", "부모님", 1000L);
+
+        //when
+        Long spendingId = spendingHistoryService.editSpendingHistory(1L, 1L, dto);
+
+        //then
+        verify(challengeRepository, times(1)).findChallengeByPlanId(1L);
+        verify(planRepository, times(1)).findById(1L);
+        verify(spendingHistoryRepository, times(1)).findById(1L);
+        verify(challenge, times(1)).isOpenedChallenge();
+        verify(plan,times(1)).getCategorySpendAmount();
+        verify(spending,times(1)).getSpendAmount();
+        verify(plan,times(1)).updateCategorySpendAmount(categorySpendAmount-spendAmount+dto.getSpendAmount());
+    }
+
+    @Test
+    @DisplayName("종료된 챌린지에 지출 내역 입력을 시도하다.")
+    void editSpendingHistory_finishChallenge(){
+        //given
+        final Challenge challenge = mock(Challenge.class);
+        final SpendingEditDto dto = mock(SpendingEditDto.class);
+
+        given(challengeRepository.findChallengeByPlanId(1L))
+                .willReturn(Optional.of(challenge));
+        given(challenge.isOpenedChallenge())
+                .willReturn(false);
+
+        //when & then
+        assertThatThrownBy(() -> spendingHistoryService.editSpendingHistory(1L, 1L, dto))
+                .isInstanceOf(SpendingPeriodInvalidException.class);
+    }
 }

--- a/src/test/java/com/nexters/jjanji/domain/challenge/domain/repository/ChallengeRepositoryTest.java
+++ b/src/test/java/com/nexters/jjanji/domain/challenge/domain/repository/ChallengeRepositoryTest.java
@@ -1,19 +1,31 @@
 package com.nexters.jjanji.domain.challenge.domain.repository;
 
 import com.nexters.jjanji.domain.challenge.domain.Challenge;
+import com.nexters.jjanji.domain.challenge.domain.Participation;
+import com.nexters.jjanji.domain.challenge.domain.Plan;
+import com.nexters.jjanji.domain.challenge.specification.PlanCategory;
+import com.nexters.jjanji.domain.member.domain.Member;
+import com.nexters.jjanji.domain.member.domain.MemberRepository;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 class ChallengeRepositoryTest {
     @Autowired ChallengeRepository challengeRepository;
+    @Autowired MemberRepository memberRepository;
+    @Autowired ParticipationRepository participationRepository;
+    @Autowired PlanRepository planRepository;
 
     @Test
     @DisplayName("다음 챌린지 조회(마지막 챌린지) 쿼리")
@@ -43,6 +55,64 @@ class ChallengeRepositoryTest {
         Challenge nextChallenge = challengeRepository.findNextChallenge();
 
         // then
-        Assertions.assertThat(nextChallenge.getId()).isEqualTo(lastCreatedChallenge.getId());
+        assertThat(nextChallenge.getId()).isEqualTo(lastCreatedChallenge.getId());
+    }
+
+    @Test
+    @DisplayName("해당 Plan의 Challenge 조회")
+    @Transactional
+    void findDistinctChallengeByPlan(){
+        //given
+        final LocalDateTime testDay = LocalDateTime.of(2023,7,13,0,0,0);
+        Challenge challenge1 = challengeRepository.save(
+                Challenge.builder()
+                        .startAt(testDay)
+                        .endAt(testDay.plusDays(7))
+                        .build());
+
+        Member member1 = memberRepository.save(
+                Member.builder()
+                        .deviceId("member1")
+                        .build()
+        );
+
+        Participation participation1 = participationRepository.save(
+                Participation.builder()
+                        .member(member1)
+                        .challenge(challenge1)
+                        .goalAmount(1000L)
+                        .build()
+        );
+
+        Plan plan1 = planRepository.save(
+                Plan.builder()
+                        .participation(participation1)
+                        .category(PlanCategory.FOOD)
+                        .categoryGoalAmount(100L)
+                        .build()
+        );
+        Plan plan2 = planRepository.save(
+                Plan.builder()
+                        .participation(participation1)
+                        .category(PlanCategory.FOOD)
+                        .categoryGoalAmount(200L)
+                        .build()
+        );
+        Plan plan3 = planRepository.save(
+                Plan.builder()
+                        .participation(participation1)
+                        .category(PlanCategory.FOOD)
+                        .categoryGoalAmount(300L)
+                        .build()
+        );
+
+        //when
+        Optional<Challenge> findChallenge = challengeRepository.findChallengeByPlanId(plan3.getId());
+
+        //then
+        assertThat(findChallenge).isPresent();
+        assertThat(findChallenge.get().getId()).isEqualTo(challenge1.getId());
+        assertThat(findChallenge.get().getStartAt()).isEqualTo(challenge1.getStartAt());
+        assertThat(findChallenge.get().getEndAt()).isEqualTo(challenge1.getEndAt());
     }
 }

--- a/src/test/java/com/nexters/jjanji/domain/challenge/presentation/SpendingHistoryControllerTest.java
+++ b/src/test/java/com/nexters/jjanji/domain/challenge/presentation/SpendingHistoryControllerTest.java
@@ -147,9 +147,9 @@ class SpendingHistoryControllerTest extends RestDocs {
                                 parameterWithName("spendingId").description("(필수) spendingId(PK)")
                         ),
                         requestFields(
-                                fieldWithPath("title").type(JsonFieldType.STRING).description("변경할 제목"),
-                                fieldWithPath("memo").type(JsonFieldType.STRING).description("변경할 메모"),
-                                fieldWithPath("spendAmount").type(JsonFieldType.NUMBER).description("변경할 소비 금액")
+                                fieldWithPath("title").type(JsonFieldType.STRING).description("(필수) 변경할 제목"),
+                                fieldWithPath("memo").type(JsonFieldType.STRING).description("(선택) 변경할 메모"),
+                                fieldWithPath("spendAmount").type(JsonFieldType.NUMBER).description("(필수) 변경할 소비 금액")
                         )
                 ));
     }


### PR DESCRIPTION
❗️ 이슈 번호
close #25 

📝 구현 내용
* 카테고리 별 지출 내역 수정 API 구현
* Rest docs 문서화

🙇🏻‍♂️ 리뷰어에게 부탁합니다!
(리뷰어에게 부탁하는 말을 작성해주세요. 없다면 지워도 됩니다!)
* 지출 내역 비지니스 로직(editSpendingHistory)을 중점적으로 리뷰 부탁드립니다.~