### PR TITLE
feat: 소비내역 등록 시 누락 기능 추가

### DIFF
--- a/src/docs/asciidoc/spending.adoc
+++ b/src/docs/asciidoc/spending.adoc
@@ -4,7 +4,10 @@
 카테고리별 소비 내역을 입력합니다.
 
 ==== 발생 가능한 예외
+- 400 : 카테고리에 해당하는 챌린지 정보가 없습니다. planId = {planId}
+- 400 : 소비내역 추가 및 변경이 가능한 기간이 아닙니다. spendingId = {spendingId}
 - 400 : 카테고리 정보가 존재하지 않습니다. planId = {planId}
+- 400 : 요청 파라미터 조건이 맞지 않습니다.
 
 ==== 요청
 *HTTP Request Example*
@@ -35,6 +38,7 @@ include::{snippets}/challenge//plan/spending/POST/http-response.adoc[]
 - 400 : 소비내역 추가 및 변경이 가능한 기간이 아닙니다. spendingId = {spendingId}
 - 400 : 카테고리 정보가 존재하지 않습니다. planId = {planId}
 - 400 : 소비내역 정보가 존재하지 않습니다. spendingId = {spendingId}
+- 400 : 요청 파라미터 조건이 맞지 않습니다.
 
 ==== 요청
 *HTTP Request Example*

--- a/src/main/java/com/nexters/jjanji/domain/challenge/application/SpendingHistoryService.java
+++ b/src/main/java/com/nexters/jjanji/domain/challenge/application/SpendingHistoryService.java
@@ -32,6 +32,9 @@ public class SpendingHistoryService {
     private final SpendingHistoryRepository spendingHistoryRepository;
     @Transactional
     public void addSpendingHistory(Long planId, SpendingSaveDto dto){
+        Challenge findChallenge = validAndGetChallengeByPlanId(planId);
+        checkOpenChallengeAndThrow(findChallenge);
+
         Plan findPlan = validAndGetPlan(planId);
         SpendingHistory createSpending = SpendingHistory.builder()
                 .title(dto.getTitle())
@@ -59,10 +62,7 @@ public class SpendingHistoryService {
     @Transactional
     public void editSpendingHistory(Long planId, Long spendingId, SpendingEditDto dto){
         Challenge findChallenge = validAndGetChallengeByPlanId(planId);
-        //현재 챌린지 일 경우에만 소비 내역 수정 가능.
-        if(!findChallenge.isOpenedChallenge()){
-            throw new SpendingPeriodInvalidException(spendingId);
-        }
+        checkOpenChallengeAndThrow(findChallenge);
 
         Plan findPlan = validAndGetPlan(planId);
 
@@ -86,6 +86,11 @@ public class SpendingHistoryService {
     private SpendingHistory validAndGetSpendingHistory(Long spendingId){
         return spendingHistoryRepository.findById(spendingId)
                 .orElseThrow(() -> new SpendingNotFoundExcpetion(spendingId));
+    }
+    private void checkOpenChallengeAndThrow(Challenge challenge){
+        if(!challenge.isOpenedChallenge()){
+            throw new SpendingPeriodInvalidException();
+        }
     }
 }
 

--- a/src/main/java/com/nexters/jjanji/domain/challenge/application/SpendingHistoryService.java
+++ b/src/main/java/com/nexters/jjanji/domain/challenge/application/SpendingHistoryService.java
@@ -32,10 +32,10 @@ public class SpendingHistoryService {
     private final SpendingHistoryRepository spendingHistoryRepository;
     @Transactional
     public void addSpendingHistory(Long planId, SpendingSaveDto dto){
-        Challenge findChallenge = validAndGetChallengeByPlanId(planId);
+        Challenge findChallenge = getChallengeByPlanIdOrThrow(planId);
         checkOpenChallengeAndThrow(findChallenge);
 
-        Plan findPlan = validAndGetPlan(planId);
+        Plan findPlan = getPlanOrThrow(planId);
         SpendingHistory createSpending = SpendingHistory.builder()
                 .title(dto.getTitle())
                 .memo(dto.getMemo())
@@ -48,7 +48,7 @@ public class SpendingHistoryService {
     }
 
     public SpendingDetailResponse findSpendingList(Long planId, Long cursorId, Pageable pageable){
-        Plan findPlan = validAndGetPlan(planId);
+        Plan findPlan = getPlanOrThrow(planId);
 
         Slice<SpendingHistory> spendingList = spendingHistoryRepository.findCursorSliceByPlan(findPlan, cursorId, pageable);
 
@@ -61,13 +61,13 @@ public class SpendingHistoryService {
 
     @Transactional
     public void editSpendingHistory(Long planId, Long spendingId, SpendingEditDto dto){
-        Challenge findChallenge = validAndGetChallengeByPlanId(planId);
+        Challenge findChallenge = getChallengeByPlanIdOrThrow(planId);
         checkOpenChallengeAndThrow(findChallenge);
 
-        Plan findPlan = validAndGetPlan(planId);
+        Plan findPlan = getPlanOrThrow(planId);
 
         //소비 내역 수정
-        SpendingHistory findSpending = validAndGetSpendingHistory(spendingId);
+        SpendingHistory findSpending = getSpendingHistoryOrThrow(spendingId);
         final Long newCategorySpendAmount = findPlan.getCategorySpendAmount() - findSpending.getSpendAmount() + dto.getSpendAmount();
         findSpending.updateSpending(dto.getTitle(), dto.getMemo(), dto.getSpendAmount());
 
@@ -75,15 +75,15 @@ public class SpendingHistoryService {
         findPlan.updateCategorySpendAmount(newCategorySpendAmount);
     }
 
-    private Plan validAndGetPlan(Long planId){
+    private Plan getPlanOrThrow(Long planId){
         return planRepository.findById(planId)
                 .orElseThrow(() -> new PlanNotFoundException(planId));
     }
-    private Challenge validAndGetChallengeByPlanId(Long planId){
+    private Challenge getChallengeByPlanIdOrThrow(Long planId){
         return challengeRepository.findChallengeByPlanId(planId)
                 .orElseThrow(() -> new PlanChallengeNotFoundException(planId));
     }
-    private SpendingHistory validAndGetSpendingHistory(Long spendingId){
+    private SpendingHistory getSpendingHistoryOrThrow(Long spendingId){
         return spendingHistoryRepository.findById(spendingId)
                 .orElseThrow(() -> new SpendingNotFoundExcpetion(spendingId));
     }

--- a/src/main/java/com/nexters/jjanji/domain/challenge/dto/request/SpendingEditDto.java
+++ b/src/main/java/com/nexters/jjanji/domain/challenge/dto/request/SpendingEditDto.java
@@ -2,6 +2,7 @@ package com.nexters.jjanji.domain.challenge.dto.request;
 
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,6 +15,7 @@ public class SpendingEditDto {
     @NotEmpty
     private String title;
     private String memo;
+    @NotNull
     @Min(value = 1)
     private Long spendAmount;
 }

--- a/src/main/java/com/nexters/jjanji/domain/challenge/dto/request/SpendingSaveDto.java
+++ b/src/main/java/com/nexters/jjanji/domain/challenge/dto/request/SpendingSaveDto.java
@@ -1,5 +1,7 @@
 package com.nexters.jjanji.domain.challenge.dto.request;
 
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotEmpty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,7 +11,9 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class SpendingSaveDto {
 
+    @NotEmpty
     private String title;
     private String memo;
+    @Min(value = 1)
     private Long spendAmount;
 }

--- a/src/main/java/com/nexters/jjanji/domain/challenge/dto/request/SpendingSaveDto.java
+++ b/src/main/java/com/nexters/jjanji/domain/challenge/dto/request/SpendingSaveDto.java
@@ -2,6 +2,7 @@ package com.nexters.jjanji.domain.challenge.dto.request;
 
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,6 +15,7 @@ public class SpendingSaveDto {
     @NotEmpty
     private String title;
     private String memo;
+    @NotNull
     @Min(value = 1)
     private Long spendAmount;
 }

--- a/src/main/java/com/nexters/jjanji/domain/challenge/presentation/SpendingHistoryController.java
+++ b/src/main/java/com/nexters/jjanji/domain/challenge/presentation/SpendingHistoryController.java
@@ -7,7 +7,6 @@ import com.nexters.jjanji.domain.challenge.dto.response.SpendingDetailResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -15,8 +14,8 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/v1/challenge/plan")
 @RequiredArgsConstructor
 public class SpendingHistoryController {
-
     private final SpendingHistoryService spendingHistoryService;
+
     @PostMapping("/{planId}/spending")
     public ResponseEntity addSpending(@PathVariable Long planId, @Valid @RequestBody SpendingSaveDto dto){
         spendingHistoryService.addSpendingHistory(planId, dto);

--- a/src/main/java/com/nexters/jjanji/domain/challenge/presentation/SpendingHistoryController.java
+++ b/src/main/java/com/nexters/jjanji/domain/challenge/presentation/SpendingHistoryController.java
@@ -18,7 +18,7 @@ public class SpendingHistoryController {
 
     private final SpendingHistoryService spendingHistoryService;
     @PostMapping("/{planId}/spending")
-    public ResponseEntity addSpending(@PathVariable Long planId,@RequestBody SpendingSaveDto dto){
+    public ResponseEntity addSpending(@PathVariable Long planId, @Valid @RequestBody SpendingSaveDto dto){
         spendingHistoryService.addSpendingHistory(planId, dto);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/nexters/jjanji/global/exception/SpendingPeriodInvalidException.java
+++ b/src/main/java/com/nexters/jjanji/global/exception/SpendingPeriodInvalidException.java
@@ -4,10 +4,10 @@ import org.springframework.http.HttpStatus;
 
 public class SpendingPeriodInvalidException extends BaseException{
 
-    public SpendingPeriodInvalidException(Long spendingId){
+    public SpendingPeriodInvalidException(){
         super(
                 HttpStatus.BAD_REQUEST,
-                String.format("소비내역 추가 및 변경이 가능한 기간이 아닙니다. spendingId = {%d}", spendingId)
+                String.format("소비내역 추가 및 변경이 가능한 기간이 아닙니다.")
         );
     }
 }

--- a/src/main/java/com/nexters/jjanji/global/exception/exhandler/BaseExControllerAdvice.java
+++ b/src/main/java/com/nexters/jjanji/global/exception/exhandler/BaseExControllerAdvice.java
@@ -3,20 +3,38 @@ package com.nexters.jjanji.global.exception.exhandler;
 import com.nexters.jjanji.global.exception.BaseException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 @Slf4j
 @RestControllerAdvice(annotations = RestController.class)
 public class BaseExControllerAdvice extends ResponseEntityExceptionHandler {
+    private final String argumentNotValidExMessage = "요청 파라미터 조건이 맞지 않습니다.";
 
     @ExceptionHandler(BaseException.class)
     public ResponseEntity<ExceptionResponse> baseExceptionHandler(BaseException e, HttpServletRequest request){
         log.warn("[BaseException 발생] request url: {}", request.getRequestURI(), e);
         return ResponseEntity.status(e.getHttpStatus()).body(new ExceptionResponse(e.getMessage()));
+    }
+
+    //MethodArgumentNotValidException 는 주로 @ExceptionHandler 으로 처리(유효성 검사 예외)
+    //BindException 는 주로 각 컨트롤러에서 처리(바인딩+유효성 검사 포괄 예외)
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request){
+        String requestURI = ((ServletWebRequest) request).getRequest().getRequestURI();
+        //현재는 필드 별 메시지 처리하지 않음. 하나의 예외 메시지로 처리
+        //TODO: 메시지 리펙토링 필요
+        log.warn("[ArgumentNotValidEx 발생] request url: {}", requestURI, ex);
+        return ResponseEntity.status(status).body(new ExceptionResponse(argumentNotValidExMessage));
     }
 
 }

--- a/src/test/java/com/nexters/jjanji/domain/challenge/application/SpendingHistoryServiceTest.java
+++ b/src/test/java/com/nexters/jjanji/domain/challenge/application/SpendingHistoryServiceTest.java
@@ -45,7 +45,13 @@ class SpendingHistoryServiceTest {
     @DisplayName("지출 내역 등록에 성공하다.")
     void addSpendingHistory(){
         //given
-        Plan plan = mock(Plan.class);
+        final Challenge challenge = mock(Challenge.class);
+        final Plan plan = mock(Plan.class);
+
+        given(challengeRepository.findChallengeByPlanId(1L))
+                .willReturn(Optional.of(challenge));
+        given(challenge.isOpenedChallenge())
+                .willReturn(true);
         given(planRepository.findById(1L))
                 .willReturn(Optional.of(plan));
 
@@ -81,7 +87,15 @@ class SpendingHistoryServiceTest {
     @DisplayName("지출 내역 등록시 계획된 카테고리가 없어 예외가 발생한다.")
     void addSpendingHistory_notExistPlan(){
         //given
-        SpendingSaveDto saveDto = new SpendingSaveDto("title", "content", 10000L);
+        final Challenge challenge = mock(Challenge.class);
+        final SpendingSaveDto saveDto = new SpendingSaveDto("title", "content", 10000L);
+
+        given(challengeRepository.findChallengeByPlanId(1L))
+                .willReturn(Optional.of(challenge));
+        given(challenge.isOpenedChallenge())
+                .willReturn(true);
+        given(planRepository.findById(1L))
+                .willReturn(Optional.ofNullable(null));
 
         //when & then
         assertThatThrownBy(() -> {

--- a/src/test/java/com/nexters/jjanji/domain/challenge/application/SpendingHistoryServiceTest.java
+++ b/src/test/java/com/nexters/jjanji/domain/challenge/application/SpendingHistoryServiceTest.java
@@ -61,6 +61,23 @@ class SpendingHistoryServiceTest {
     }
 
     @Test
+    @DisplayName("종료된 챌린지에 지출 내역 등록을 시도하다.")
+    void addSpendingHistory_finishChallenge(){
+        //given
+        final Challenge challenge = mock(Challenge.class);
+        final SpendingSaveDto dto = mock(SpendingSaveDto.class);
+
+        given(challengeRepository.findChallengeByPlanId(1L))
+                .willReturn(Optional.of(challenge));
+        given(challenge.isOpenedChallenge())
+                .willReturn(false);
+
+        //when & then
+        assertThatThrownBy(() -> spendingHistoryService.addSpendingHistory(1L, dto))
+                .isInstanceOf(SpendingPeriodInvalidException.class);
+    }
+
+    @Test
     @DisplayName("지출 내역 등록시 계획된 카테고리가 없어 예외가 발생한다.")
     void addSpendingHistory_notExistPlan(){
         //given
@@ -149,7 +166,7 @@ class SpendingHistoryServiceTest {
     }
 
     @Test
-    @DisplayName("종료된 챌린지에 지출 내역 입력을 시도하다.")
+    @DisplayName("종료된 챌린지에 지출 내역 수정을 시도하다.")
     void editSpendingHistory_finishChallenge(){
         //given
         final Challenge challenge = mock(Challenge.class);

--- a/src/test/java/com/nexters/jjanji/domain/challenge/presentation/SpendingHistoryControllerTest.java
+++ b/src/test/java/com/nexters/jjanji/domain/challenge/presentation/SpendingHistoryControllerTest.java
@@ -111,9 +111,9 @@ class SpendingHistoryControllerTest extends RestDocs {
                                 parameterWithName("planId").description("(필수) planId(PK)")
                         ),
                         requestFields(
-                                fieldWithPath("title").type(JsonFieldType.STRING).description("제목"),
-                                fieldWithPath("memo").type(JsonFieldType.STRING).description("메모"),
-                                fieldWithPath("spendAmount").type(JsonFieldType.NUMBER).description("소비 금액")
+                                fieldWithPath("title").type(JsonFieldType.STRING).description("(필수) 제목, 빈값 & NULL 허용 x"),
+                                fieldWithPath("memo").type(JsonFieldType.STRING).description("(선택) 메모"),
+                                fieldWithPath("spendAmount").type(JsonFieldType.NUMBER).description("(필수) 소비 금액, NULL 허용 x & 최소 1원 이상")
                         )
                 ));
     }
@@ -147,9 +147,9 @@ class SpendingHistoryControllerTest extends RestDocs {
                                 parameterWithName("spendingId").description("(필수) spendingId(PK)")
                         ),
                         requestFields(
-                                fieldWithPath("title").type(JsonFieldType.STRING).description("(필수) 변경할 제목"),
+                                fieldWithPath("title").type(JsonFieldType.STRING).description("(필수) 변경할 제목, 빈값 & NULL 허용 x"),
                                 fieldWithPath("memo").type(JsonFieldType.STRING).description("(선택) 변경할 메모"),
-                                fieldWithPath("spendAmount").type(JsonFieldType.NUMBER).description("(필수) 변경할 소비 금액")
+                                fieldWithPath("spendAmount").type(JsonFieldType.NUMBER).description("(필수) 변경할 소비 금액, NULL 허용 x & 최소 1원 이상")
                         )
                 ));
     }


### PR DESCRIPTION
❗️ 이슈 번호
close #27 

📝 구현 내용
* 소비 내역 등록 시 현재 챌린지 검증 기능
* Bean validation 추가 및 전역 예외 핸들러 추가
* rest docs 누락 설명 및 발생 가능 예외 추가
