### PR TITLE
feat: 참여 내역 삭제 api 구현

### DIFF
--- a/src/docs/asciidoc/challenge.adoc
+++ b/src/docs/asciidoc/challenge.adoc
@@ -68,6 +68,31 @@ Response HTTP Example
 *정상*
 include::{snippets}/challenge/participate/POST/http-response.adoc[]
 
+=== 챌린지 참여 내역 삭제
+
+챌린지 참여 내역을 삭제합니다.
+
+플랜 기록들도 모두 삭제됩니다.
+
+==== 요청
+HTTP Example
+
+include::{snippets}/challenge/participate/DELETE/http-request.adoc[]
+
+Request Header
+
+include::{snippets}/challenge/participate/DELETE/request-headers.adoc[]
+
+Path Parameters
+
+include::{snippets}/challenge/participate/DELETE/path-parameters.adoc[]
+
+==== 응답
+Response HTTP Example
+
+*정상*
+include::{snippets}/challenge/participate/DELETE/http-response.adoc[]
+
 === 카테고리별 계획 등록
 
 다음 챌린지의 카테고리 계획을 등록합니다.

--- a/src/main/java/com/nexters/jjanji/domain/challenge/application/ChallengeService.java
+++ b/src/main/java/com/nexters/jjanji/domain/challenge/application/ChallengeService.java
@@ -7,6 +7,7 @@ import com.nexters.jjanji.domain.challenge.domain.repository.ChallengeRepository
 import com.nexters.jjanji.domain.challenge.domain.repository.ParticipationDao;
 import com.nexters.jjanji.domain.challenge.domain.repository.ParticipationRepository;
 import com.nexters.jjanji.domain.challenge.domain.repository.PlanRepository;
+import com.nexters.jjanji.domain.challenge.domain.repository.SpendingHistoryRepository;
 import com.nexters.jjanji.domain.challenge.dto.request.ParticipateRequestDto;
 import com.nexters.jjanji.domain.challenge.dto.request.CreateCategoryPlanRequestDto;
 import com.nexters.jjanji.domain.challenge.dto.request.UpdateGoalAmountRequestDto;
@@ -36,6 +37,7 @@ public class ChallengeService {
     private final MemberRepository memberRepository;
     private final PlanRepository planRepository;
     private final TransactionTemplate transactionTemplate;
+    private final SpendingHistoryRepository spendingHistoryRepository;
 
     public Challenge weeklySchedulerProcess() {
         Challenge prevChallenge = challengeRepository.findChallengeByState(ChallengeState.OPENED)
@@ -95,6 +97,15 @@ public class ChallengeService {
                 .goalAmount(participateRequestDto.getGoalAmount())
                 .build();
         participationRepository.save(participation);
+    }
+
+    @Transactional(readOnly = true)
+    public void deleteParticipate(Long memberId, Long participationId) {
+        Participation participation = participationRepository.findById(participationId).orElseThrow(NotParticipateException::new);
+        if (!participation.getMember().getId().equals(memberId)) {
+            throw new NotParticipateException();
+        }
+        participationRepository.deleteParticipationBulk(participation.getId());
     }
 
     @Transactional

--- a/src/main/java/com/nexters/jjanji/domain/challenge/domain/repository/ParticipationRepository.java
+++ b/src/main/java/com/nexters/jjanji/domain/challenge/domain/repository/ParticipationRepository.java
@@ -24,4 +24,11 @@ public interface ParticipationRepository extends JpaRepository<Participation, Lo
             "where c.challenge_id = :currentChallengeId",
             nativeQuery = true)
     void copyPreviousParticipate(@Param("currentChallengeId") Long currentChallengeId, @Param("nextChallengeId") Long nextChallengeId);
+
+    @Modifying
+    @Query(value = "delete participation, plan, spending_history " +
+            "from participation " +
+            "left join plan on plan.participation_id = :participationId " +
+            "left join spending_history on plan.plan_id = spending_history.plan_id", nativeQuery = true)
+    void deleteParticipationBulk(@Param("participationId") Long participationId);
 }

--- a/src/main/java/com/nexters/jjanji/domain/challenge/presentation/ChallengeController.java
+++ b/src/main/java/com/nexters/jjanji/domain/challenge/presentation/ChallengeController.java
@@ -1,14 +1,18 @@
 package com.nexters.jjanji.domain.challenge.presentation;
 
 import com.nexters.jjanji.domain.challenge.application.ChallengeService;
+import com.nexters.jjanji.domain.challenge.domain.repository.ParticipationRepository;
 import com.nexters.jjanji.domain.challenge.dto.request.CreateCategoryPlanRequestDto;
 import com.nexters.jjanji.domain.challenge.dto.request.ParticipateRequestDto;
 import com.nexters.jjanji.domain.challenge.dto.request.UpdateGoalAmountRequestDto;
 import com.nexters.jjanji.domain.challenge.dto.response.ParticipationResponseDto;
 import com.nexters.jjanji.global.auth.MemberContext;
 import jakarta.validation.Valid;
+import jakarta.websocket.server.PathParam;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -24,11 +28,18 @@ import java.util.List;
 public class ChallengeController {
 
     private final ChallengeService challengeService;
+    private final ParticipationRepository participationRepository;
 
     @GetMapping("/participate")
     public List<ParticipationResponseDto> getParticipateList(@RequestParam(required = false) Long cursor, @RequestParam Long size) {
         Long memberId = MemberContext.getMember();
         return challengeService.getParticipateList(memberId, cursor, size);
+    }
+
+    @DeleteMapping("/participate/{participationId}")
+    public void deleteParticipate(@PathVariable Long participationId) {
+        Long memberId = MemberContext.getMember();
+        challengeService.deleteParticipate(memberId, participationId);
     }
 
     @PutMapping("/participate/goalAmount")

--- a/src/test/java/com/nexters/jjanji/domain/challenge/domain/repository/ParticipationRepositoryTest.java
+++ b/src/test/java/com/nexters/jjanji/domain/challenge/domain/repository/ParticipationRepositoryTest.java
@@ -2,6 +2,9 @@ package com.nexters.jjanji.domain.challenge.domain.repository;
 
 import com.nexters.jjanji.domain.challenge.domain.Challenge;
 import com.nexters.jjanji.domain.challenge.domain.Participation;
+import com.nexters.jjanji.domain.challenge.domain.Plan;
+import com.nexters.jjanji.domain.challenge.domain.SpendingHistory;
+import com.nexters.jjanji.domain.challenge.specification.PlanCategory;
 import com.nexters.jjanji.domain.member.domain.Member;
 import com.nexters.jjanji.domain.member.domain.MemberRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -23,6 +26,10 @@ class ParticipationRepositoryTest {
     @Autowired ParticipationRepository participationRepository;
     @Autowired
     private MemberRepository memberRepository;
+    @Autowired
+    private PlanRepository planRepository;
+    @Autowired
+    private SpendingHistoryRepository spendingHistoryRepository;
 
     @Test
     @DisplayName("다음 챌린지에 이전 참가자들의 참가 내역이 복사된다.")
@@ -61,5 +68,50 @@ class ParticipationRepositoryTest {
         assertThat(byMemberAndChallenge.get().getGoalAmount()).isEqualTo(10000L);
         assertThat(byMemberAndChallenge.get().getMember()).isEqualTo(member);
         assertThat(byMemberAndChallenge.get().getChallenge()).isEqualTo(nextChallenge);
+    }
+
+    @Test
+    @DisplayName("참가 내역이 모두 삭제된다.")
+    void deleteParticipateHistory() {
+        // given
+        Member member = memberRepository.save(
+                Member.builder()
+                        .deviceId("test-device-id")
+                        .build()
+        );
+        LocalDateTime testDate = LocalDateTime.of(2021, 8, 1, 0, 0, 0);
+        Challenge challenge = challengeRepository.save(
+                Challenge.builder()
+                        .startAt(testDate.plusDays(0))
+                        .endAt(testDate.plusDays(7))
+                        .build());
+
+        Participation participation = participationRepository.save(
+                Participation.builder()
+                        .challenge(challenge)
+                        .goalAmount(10000L)
+                        .member(memberRepository.getReferenceById(member.getId()))
+                        .build()
+        );
+        Plan plan = planRepository.save(Plan.builder()
+                .participation(participation)
+                .category(PlanCategory.FOOD)
+                .categoryGoalAmount(10000L)
+                .build());
+
+        spendingHistoryRepository.save(SpendingHistory.builder()
+                .plan(plan)
+                .title("title")
+                .memo("memo")
+                .spendAmount(0L)
+                .build());
+
+        // when
+        participationRepository.deleteParticipationBulk(participation.getId());
+
+        // then
+        assertThat(participationRepository.count()).isZero();
+        assertThat(planRepository.count()).isZero();
+        assertThat(spendingHistoryRepository.count()).isZero();
     }
 }


### PR DESCRIPTION
❗️ 이슈 번호
close #49 


📝 구현 내용
(가능한 한 자세히 작성해 주시면 감사하겠습니다!)

- 참여 내역 삭제 api 구현.
- 참여내역, 소비 계획, 소비 내역 모두 삭제합니다.

🙇🏻‍♂️ 리뷰어에게 부탁합니다!
(리뷰어에게 부탁하는 말을 작성해주세요. 없다면 지워도 됩니다!)



💡 참고 자료
(없다면 지워도 됩니다!)